### PR TITLE
Fixes bug on external url in page highlight

### DIFF
--- a/src/components/call-to-action.js
+++ b/src/components/call-to-action.js
@@ -19,16 +19,15 @@ function CallToAction({ title, description, url, urlTitle }) {
         <Division />
         <p className="mt-5 text-rg text-center">{description}</p>
       </div>
-      {isExternalLink && url ? (
+      {!url ? null : isExternalLink ? (
         <a className="btn btn--primary mt-5 w-1/2" href={url} target="_blank">
           {urlTitle}
         </a>
-      ) : null}
-      {!isExternalLink && url ? (
+      ) : (
         <Link to={url} className="btn btn--primary mt-5 w-1/2">
           {urlTitle}
         </Link>
-      ) : null}
+      )}
     </Card>
   );
 }

--- a/src/components/page-highlight.js
+++ b/src/components/page-highlight.js
@@ -5,14 +5,14 @@ import { Link } from "gatsby";
 import styles from "./page-highlight.module.css";
 
 function PageHighlight({ header, subheader, url, urlTitle }) {
-  let isExternalUrl = url.indexOf("https") || url.indexOf("www");
+  let isExternalUrl = url.includes("https");
 
   return (
     <section className="py-7 px-2 bg-primary lg:py-10 lg:px-10">
       <div className="m-auto text-center w-11/12 max-w-6xl lg:w-10/12">
         <h3 className="text-h3 text-white font-extrabold mb-4">{header}</h3>
         <h4 className="text-h4 text-white mb-6">{subheader}</h4>
-        {isExternalUrl > 0 ? (
+        {isExternalUrl ? (
           <a
             href={url}
             className={`btn btn--inverse ${styles.cta}`}


### PR DESCRIPTION
# What changed and why
Currently our `PageHighlight` has a bug that assigns an `href` to the incorrect component. In `PageHighlight` we have two types or urls, external and internal. The external urls are managed by the html `a` element and the internal one is managed by the `Link` component provided by Gatsby. Our component is using `Link` component from Gatsby to manage an external url and its resulting in a 404 not found error.