### PR TITLE
Improve Developer Experience

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  globals: {
+    __PATH_PREFIX__: true
+  },
+  extends: `react-app`,
+  rules: {
+    "no-unused-vars": [
+      "error",
+      { vars: "all", args: "after-used", ignoreRestSiblings: false }
+    ]
+  }
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,10 @@ jobs:
         uses: actions/checkout@master
       - name: Install
         run: yarn
+      - name: Lint
+        run: npm run lint
       - name: Build
-        run: npx gatsby build
+        run: npm run build
       - name: Percy Test
         uses: percy/snapshot-action@v0.1.0
         with:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.formatOnSave": true,
+  "files.exclude": {
+    "**/node_modules": true,
+    "public": true,
+    ".cache": true
+  },
+  "editor.tabSize": 2
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,18 @@ module.exports = {
           include: /\.inline\.svg$/
         }
       }
+    },
+    {
+      resolve: "gatsby-plugin-eslint",
+      options: {
+        test: /\.js$|\.jsx$/,
+        exclude: /(node_modules|.cache|public)/,
+        stages: ["develop", "build-javascript"],
+        options: {
+          emitWarning: true,
+          failOnError: false
+        }
+      }
     }
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^1.3.0",
+    "eslint-config-react-app": "^5.1.0",
+    "gatsby-plugin-eslint": "^2.0.8",
     "gatsby-plugin-react-svg": "^2.1.2",
     "prettier": "^1.18.2"
   },
@@ -37,6 +39,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
+    "lint": "eslint src",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "repository": {

--- a/src/components/call-to-action.js
+++ b/src/components/call-to-action.js
@@ -20,7 +20,12 @@ function CallToAction({ title, description, url, urlTitle }) {
         <p className="mt-5 text-rg text-center">{description}</p>
       </div>
       {!url ? null : isExternalLink ? (
-        <a className="btn btn--primary mt-5 w-1/2" href={url} target="_blank">
+        <a
+          className="btn btn--primary mt-5 w-1/2"
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           {urlTitle}
         </a>
       ) : (

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -7,22 +7,11 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { useStaticQuery, graphql } from "gatsby";
 
 import Menu from "./menu";
 import Footer from "./footer";
 
 const Layout = ({ children }) => {
-  const data = useStaticQuery(graphql`
-    query SiteTitleQuery {
-      site {
-        siteMetadata {
-          title
-        }
-      }
-    }
-  `);
-
   return (
     <>
       <Menu />

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -16,7 +16,8 @@ const NotFoundPage = () => (
             <img
               src="https://media.giphy.com/media/a9xhxAxaqOfQs/source.gif"
               className="lg:w-1/2 md:w-full"
-            ></img>
+              alt="Sad David Tennant in the rain"
+            />
           </div>
         </div>
       </div>

--- a/src/pages/schedule.js
+++ b/src/pages/schedule.js
@@ -29,6 +29,7 @@ export default function() {
           className="btn btn--primary w-1/2 lg:w-2/12"
           href="https://fullstacknights.eventbrite.com"
           target="_blank"
+          rel="noopener noreferrer"
         >
           Get tickets
         </a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,7 +3015,7 @@ configstore@^5.0.0:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
-confusing-browser-globals@^1.0.7:
+confusing-browser-globals@^1.0.7, confusing-browser-globals@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
   integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
@@ -4193,6 +4193,13 @@ eslint-config-react-app@^4.0.1:
   dependencies:
     confusing-browser-globals "^1.0.7"
 
+eslint-config-react-app@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-5.1.0.tgz#a37b3f2d4f56f856f93277281ef52bd791273e63"
+  integrity sha512-hBaxisHC6HXRVvxX+/t1n8mOdmCVIKgkXsf2WoUkJi7upHJTwYTsdCmx01QPOjKNT34QMQQ9sL0tVBlbiMFjxA==
+  dependencies:
+    confusing-browser-globals "^1.0.9"
+
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -5186,6 +5193,11 @@ gatsby-page-utils@^0.0.21:
     lodash "^4.17.15"
     micromatch "^3.1.10"
     slash "^3.0.0"
+
+gatsby-plugin-eslint@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-eslint/-/gatsby-plugin-eslint-2.0.8.tgz#1ff7f546a427d274dc2de3932ba29822aae330c3"
+  integrity sha512-vAMy37povmQJNg6ZxY78fkWR3pKwG8MNMhO3u+4vXj2MYT5avhFvHPJTAb126ZCuygf30gAWlpwbV50zP894Jw==
 
 gatsby-plugin-manifest@^2.2.18:
   version "2.2.18"


### PR DESCRIPTION
## What changed and why
This PR enhances the developer experience when working on this project. Steps taken to provide a better experience:
1. Add a list of recommended extensions to vscode. In this case, I only added prettier and eslint.
2. Add a settings.json that will be used by vscode. In this case, I added a format on save rule and excluded the node_modules, .cache and public directories.
3. Take control of ESLint. By default, Gatsby has control over ESLint and it shows erros and warnings on the console. This is fine but I find that having the warnings and errors shown on the editor is more actionable than having them on the console and to do that we need the `.eslintrc.js` on our project and the eslint plugin installed. 
4. When we take control of the ESLint Gatsby stops showing errors and warnings on the console. This is not ideal because we cannot see whats the state of the entire project. To work around this I added `gatsby-plugin-eslint` so Gatsby can show errors on the console.
5. Make the build fail when ESLint finds errors on our project. To do this I changed the `npx gatsby build` command on the `ci.yml` for `npm run build`. NPM run build will run `npm run lint && gatsby build` when ESLint find an error the build will fail :).